### PR TITLE
Version 2022.1.5 with another "no DID" fix

### DIFF
--- a/src/components/Settings/__snapshots__/Settings.test.tsx.snap
+++ b/src/components/Settings/__snapshots__/Settings.test.tsx.snap
@@ -115,7 +115,7 @@ exports[`Settings menu should be visible when menu button clicked 1`] = `
             role="menuitem"
             tabindex="-1"
           >
-            Version 2021.12.30
+            Version 2022.1.5
           </a>
         </li>
       </ul>
@@ -225,7 +225,7 @@ exports[`Settings should render the endpoint item in the internal build 1`] = `
             role="menuitem"
             tabindex="-1"
           >
-            Version 2021.12.30
+            Version 2022.1.5
           </a>
         </li>
       </ul>

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -22,7 +22,7 @@ export const internalFeatures: Features = {
 
 // Duplicates the value in src/static/manifest.json
 // We can’t use browser.runtime.getManifest().version, as it’s unavailable in injected scripts
-const version = '2021.12.30';
+const version = '2022.1.5';
 
 export const configuration: ConfigurationType = {
   version,

--- a/src/static/manifest.json
+++ b/src/static/manifest.json
@@ -3,7 +3,7 @@
   "name": "__MSG_manifest_name__",
   "short_name": "__MSG_manifest_short_name__",
   "description": "__MSG_manifest_description__",
-  "version": "2021.12.30",
+  "version": "2022.1.5",
   "default_locale": "en",
   "browser_action": {
     "default_icon": {

--- a/src/utilities/credentials/credentials.ts
+++ b/src/utilities/credentials/credentials.ts
@@ -64,12 +64,14 @@ export function useCredentials(): Credential[] {
   return useContext(CredentialsContext);
 }
 
-export function useIdentityCredentials(did?: IDidDetails['did']): Credential[] {
+const noCredentials: Credential[] = [];
+
+export function useIdentityCredentials(did: IDidDetails['did']): Credential[] {
   const all = useCredentials();
 
   return useMemo(() => {
     if (!did) {
-      return all;
+      return noCredentials;
     }
     const { fullDid } = parseDidUrl(did);
     return all.filter(

--- a/src/views/SaveCredential/SaveCredential.tsx
+++ b/src/views/SaveCredential/SaveCredential.tsx
@@ -6,7 +6,7 @@ import * as styles from './SaveCredential.module.css';
 
 import {
   getCredentialDownload,
-  useIdentityCredentials,
+  useCredentials,
 } from '../../utilities/credentials/credentials';
 import { usePopupData } from '../../utilities/popups/usePopupData';
 
@@ -19,7 +19,7 @@ export function SaveCredential(): JSX.Element | null {
 
   const { claimHash } = usePopupData<IAttestation>();
 
-  const credentials = useIdentityCredentials();
+  const credentials = useCredentials();
 
   const credential = credentials.find(
     (credential) => credential.request.rootHash === claimHash,

--- a/src/views/ShareCredentialSelect/ShareCredentialSelect.tsx
+++ b/src/views/ShareCredentialSelect/ShareCredentialSelect.tsx
@@ -41,11 +41,11 @@ function MatchingIdentityCredentials({
 
   const credentials = useIdentityCredentials(identity.did);
 
+  const fullDid = identity.did && parseDidUrl(identity.did).fullDid;
   const matchingCredentials = credentials?.filter(
     (credential) =>
       cTypeHashes.includes(credential.request.claim.cTypeHash) &&
-      parseDidUrl(credential.request.claim.owner).fullDid ===
-        parseDidUrl(identity.did).fullDid,
+      parseDidUrl(credential.request.claim.owner).fullDid === fullDid,
   );
 
   useEffect(() => {


### PR DESCRIPTION
An identity without DID will not show any credentials. Sharing credentials will now work even if one of the identities still has no DID. 